### PR TITLE
remove outputs from yaml. The latest version of the 'moby' tool now r…

### DIFF
--- a/sshd.example.yml
+++ b/sshd.example.yml
@@ -46,7 +46,3 @@ trust:
 files:
   - path: root/.ssh/authorized_keys
     contents: "# copy your id_rsa.pub contents here"
-outputs:
-  - format: kernel+initrd
-  - format: iso-bios
-  - format: iso-efi


### PR DESCRIPTION
…equires

that the output formats be specified in the CLI not in the yaml file.

You'll probably also want to update your blog post with passing the outputs on CLI.

Thanks for your blog!